### PR TITLE
add waiting list management for tours

### DIFF
--- a/models/tourModel.js
+++ b/models/tourModel.js
@@ -29,6 +29,30 @@ const tourSchema = new mongoose.Schema(
       type: Boolean,
       default: false,
     },
+
+    waitingListAvailability: {
+      type: Boolean,
+      required: true,
+    },
+
+    waitingList: [
+      {
+        user: {
+          type: mongoose.Schema.ObjectId,
+          ref: 'User',
+          required: true,
+        },
+        joinedAt: {
+          type: Date,
+          default: Date.now,
+        },
+      },
+    ],
+
+    waitingListLimit: {
+      type: Number,
+    },
+
     difficulty: {
       type: String,
       required: [true, 'A tour must have a difficulty'],

--- a/routes/tourRoutes.js
+++ b/routes/tourRoutes.js
@@ -45,6 +45,13 @@ router
     tourService.createTour,
   );
 
+// ---------------------------------------------------
+// The below routes handles waiting list logic
+router.route('/:id/waiting-list').patch(tourService.addToWaitingList);
+
+router.route('/:id/waiting-list/:userId').delete(tourService.exitWaitingList);
+
+// ---------------------------------------------------
 router
   .route('/:id')
   .get(getTourValidator, tourService.getTour)


### PR DESCRIPTION
## Overview  
Implemented a waiting list feature for tours. Users can join or leave the waiting list, and validation is enforced to respect the maximum participant limit.  

## How to Test  
- **Add participants** to a tour’s waiting list via:  
  `POST /api/v1/tours/:id/waiting-list`  
  - Payload can include one or multiple users.  
  - If the limit is exceeded, an error is returned.  

- **Remove participants** from the waiting list via:  
  `DELETE /api/v1/tours/:id/waiting-list/:userId`  